### PR TITLE
Move cities.spec.js to test directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:json2js": "echo 'export default' > src/geo.js && cat src/geo.json >> src/geo.js",
     "build": "npm run build:json2js && npm run build:rollup",
     "prepublish": "npm run build",
-    "test": "node --test src/cities.spec.js"
+    "test": "node --test test/cities.spec.js"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",

--- a/test/cities.spec.js
+++ b/test/cities.spec.js
@@ -1,7 +1,7 @@
 import {test} from 'node:test';
 import assert from 'node:assert';
 import {Location} from '@hebcal/core';
-import './cities.js';
+import '../src/cities.js';
 
 test('lookup', () => {
   let city = Location.lookup('Rishon LeZiyyon');


### PR DESCRIPTION
Relocates the test file from `src/` into a dedicated `test/` directory.

## Changes
- Move `src/cities.spec.js` → `test/cities.spec.js`
- Fix the relative import to `../src/cities.js`
- Update the `test` script to point at the new location

All 8 tests pass via `node --test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HziyFvKMgCH5oPMGTi8HCJ)_